### PR TITLE
allow to compare with setted by user epsilon

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,14 @@ macro_rules! assert_approx_eq {
                 "assertion failed: `(left !== right)` \
                            (left: `{:?}`, right: `{:?}`)",
                  *a, *b);
-    })
+    });
+    ($a:expr, $b:expr, $eps:expr) => ({
+        let (a, b) = (&$a, &$b);
+        assert!((*a - *b).abs() < $eps,
+                "assertion failed: `(left !== right)` \
+                           (left: `{:?}`, right: `{:?}`, expect diff: `{:?}`, real diff: `{:?}`)",
+                 *a, *b, $eps, (*a - *b).abs());
+    })  
 }
 
 #[test]
@@ -30,4 +37,15 @@ fn it_should_not_panic_if_values_are_approx_equal() {
 #[should_panic]
 fn it_should_panic_if_values_are_not_approx_equal() {
   assert_approx_eq!(3 as f32, 4 as f32);
+}
+
+#[test]
+fn compare_with_explicit_eps() {
+    assert_approx_eq!(3f64, 4f64, 2f64);
+}
+
+#[test]
+#[should_panic]
+fn bad_compare_with_explicit_eps() {
+    assert_approx_eq!(3f64, 4f64, 1e-3f64);
 }


### PR DESCRIPTION
1e-6 not always good choice, espesially if work with `f64`.