### PR TITLE
Use Rust 2018 `use` syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 /// # Examples
 ///
 /// ```should panic
-/// # #[macro_use] extern crate assert_approx_eq;
+/// use assert_approx_eq::assert_approx_eq;
 ///
 /// let a = 3f64;
 /// let b = 4f64;


### PR DESCRIPTION
I'm just so happy the `#[macro_use]` imports are no longer a thing. :)